### PR TITLE
Make it work with v0.12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "http://rubygems.org"
 
 gemspec
 gem 'test-unit'
+gem 'fluent-plugin-grep'
+gem 'pry-nav'

--- a/Gemfile.fluentd.v10
+++ b/Gemfile.fluentd.v10
@@ -3,3 +3,4 @@ source "http://rubygems.org"
 gemspec
 gem 'fluentd', '~> 0.10.0'
 gem 'test-unit'
+gem 'fluent-plugin-grep'

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Use RubyGems:
 As an example, let's profile how long the [emit](https://github.com/sonots/fluent-plugin-grep/blob/master/lib/fluent/plugin/out_grep.rb#L56) method of [fluent-plugin-grep](https://github.com/sonots/fluent-plugin-grep) is taking.
 Configure fluentd.conf as below:
 
+For Fluentd v0.10:
+
 ```apache
 <source>
   type measure_time
@@ -59,7 +61,43 @@ Configure fluentd.conf as below:
     tag measure_time
     hook emit
   </measure_time>
+</match>
+```
+
+For Fluentd v0.12:
+
+```apache
+<label @measure_time>
+  <match>
+    @type measure_time
+    # This makes available the `measure_time` directive for all plugins
+  </match>
+</label>
+
+<source>
+  @type dummy
+  tag raw.dummy
+  dummy {"message":"foo"}
 </source>
+
+# measure_time plugin output comes here
+<match measure_time>
+  @type stdout
+</match>
+
+# Whatever you want to do
+<match greped.**>
+  @type stdout
+</match>
+
+<match **>
+  @type grep
+  add_tag_prefix greped
+  <measure_time>
+    tag measure_time
+    hook emit
+  </measure_time>
+</match>
 ```
 
 The output of fluent-plugin-measure_time will be as below:
@@ -114,6 +152,8 @@ This profiling is very useful to investigate when you have a suspicion that thro
 
 The configuration will be as follows:
 
+For Fluentd v0.10:
+
 ```apache
 <source>
   type measure_time
@@ -136,6 +176,35 @@ The configuration will be as follows:
 # whatever you want
 <match **>
   type stdout
+</match>
+```
+
+For Fluentd v0.12:
+
+```apache
+<label @measure_time>
+  <match>
+    @type measure_time
+    # This makes available the `measure_time` directive for all plugins
+  </match>
+</match>
+
+<source>
+  @type forward
+  port 24224
+  <measure_time>
+    tag measure_time
+    hook on_message
+  </measure_time>
+</source>
+
+<match measure_time>
+  @type stdout
+</match>
+
+# whatever you want
+<match **>
+  @type stdout
 </match>
 ```
 

--- a/example/v0.10.conf
+++ b/example/v0.10.conf
@@ -1,0 +1,29 @@
+<source>
+  type measure_time
+  # This makes available the `measure_time` directive for all plugins
+</source>
+
+<source>
+  type dummy
+  tag raw.dummy
+  dummy {"message":"test"}
+</source>
+
+# measure_time plugin output comes here
+<match measure_time>
+  type stdout
+</match>
+
+# Whatever you want to do
+<match greped.**>
+  type stdout
+</match>
+
+<match **>
+  type grep
+  add_tag_prefix greped
+  <measure_time>
+    tag measure_time
+    hook emit
+  </measure_time>
+</match>

--- a/example/v0.12.conf
+++ b/example/v0.12.conf
@@ -1,0 +1,31 @@
+<label @measure_time>
+  <match>
+    @type measure_time
+    # This makes available the `measure_time` directive for all plugins
+  </match>
+</label>
+
+<source>
+  @type dummy
+  tag raw.dummy
+  dummy {"message":"foo"}
+</source>
+
+# measure_time plugin output comes here
+<match measure_time>
+  @type stdout
+</match>
+
+# Whatever you want to do
+<match greped.**>
+  @type stdout
+</match>
+
+<match **>
+  @type grep
+  add_tag_prefix greped
+  <measure_time>
+    tag measure_time
+    hook emit
+  </measure_time>
+</match>

--- a/lib/fluent/plugin/measure_timable.rb
+++ b/lib/fluent/plugin/measure_timable.rb
@@ -1,0 +1,129 @@
+module Fluent
+  module MeasureTimable
+    def self.included(klass)
+      unless klass.method_defined?(:configure_without_measure_time)
+        klass.__send__(:alias_method, :configure_without_measure_time, :configure)
+        klass.__send__(:alias_method, :configure, :configure_with_measure_time)
+      end
+
+      unless klass.method_defined?(:router)
+        define_method(:router) { ::Fluent::Engine }
+      end
+    end
+
+    attr_reader :measure_time
+
+    def configure_with_measure_time(conf)
+      configure_without_measure_time(conf)
+      if element = conf.elements.select { |element| element.name == 'measure_time' }.first
+        @measure_time = MeasureTime.new(self, log, router)
+        @measure_time.configure(element)
+      end
+    end
+  end
+
+  class MeasureTime
+    attr_reader :plugin, :log, :router, :times, :mutex, :thread, :tag, :interval, :hook
+    def initialize(plugin, log, router)
+      @plugin = plugin
+      @klass = @plugin.class
+      @log = log
+      @router = router
+      @times = []
+      @mutex = Mutex.new
+    end
+
+    def configure(conf)
+      @tag = conf['tag'] || 'measure_time'
+      unless @hook = conf['hook']
+        raise Fluent::ConfigError, '`hook` option must be specified in <measure_time></measure_time> directive'
+      end
+      @hook_msg = {:class => @klass.to_s, :hook => @hook.to_s, :object_id => @plugin.object_id.to_s}
+      @interval = conf['interval'].to_i if conf['interval']
+      @add_or_emit_proc =
+        if @interval
+          # add to calculate statistics in each interval
+          Proc.new {|elapsed|
+            @mutex.synchronize { @times << elapsed }
+          }
+        else
+          # emit information immediately
+          Proc.new {|elapsed|
+            msg = {:time => elapsed}.merge(@hook_msg)
+            router.emit(@tag, ::Fluent::Engine.now, msg)
+          }
+        end
+      apply_hook
+    end
+
+    def apply_hook
+      @plugin.instance_eval <<EOF
+        def #{@hook}(*args)
+          measure_time.measure_time do
+            super
+          end
+        end
+        def start
+          super
+          measure_time.start
+        end
+        def stop
+          super
+          measure_time.stop
+        end
+EOF
+    end
+
+    def measure_time
+      started = Time.now
+      output = yield
+      elapsed = (Time.now - started).to_f
+      log.debug "elapsed time at #{@klass}##{@hook} is #{elapsed} sec"
+      @add_or_emit_proc.call(elapsed)
+      output
+    end
+
+    def start
+      return unless @interval
+      @thread = Thread.new(&method(:run))
+    end
+
+    def stop
+      return unless @interval
+      @thread.terminate
+      @thread.join
+    end
+
+    def run
+      @last_checked ||= ::Fluent::Engine.now
+      while (sleep 0.5)
+        begin
+          now = ::Fluent::Engine.now
+          if now - @last_checked >= @interval
+            flush(now)
+            @last_checked = now
+          end
+        rescue => e
+          log.warn "in_measure_time: hook #{@klass}##{@hook} #{e.class} #{e.message} #{e.backtrace.first}"
+        end
+      end
+    end
+
+    def flush(now)
+      times = []
+      @mutex.synchronize do
+        times = @times.dup
+        @times.clear
+      end
+      triple = nil
+      unless times.empty?
+        num = times.size
+        max = num == 0 ? 0 : times.max
+        avg = num == 0 ? 0 : times.map(&:to_f).inject(:+) / num.to_f
+        triple = [@tag, now, {:max => max, :avg => avg, :num => num}.merge(@hook_msg)]
+        router.emit(*triple)
+      end
+      triple
+    end
+  end
+end

--- a/lib/fluent/plugin/out_measure_time.rb
+++ b/lib/fluent/plugin/out_measure_time.rb
@@ -1,8 +1,8 @@
 require 'fluent/plugin/measure_timable'
 
 module Fluent
-  class MeasureTimeInput < Input
-    Plugin.register_input('measure_time', self)
+  class MeasureTimeOutput < Output
+    Plugin.register_output('measure_time', self)
 
     unless method_defined?(:router)
       define_method(:router) { ::Fluent::Engine }
@@ -11,6 +11,9 @@ module Fluent
     def configure(conf)
       ::Fluent::Input.__send__(:include, MeasureTimable)
       ::Fluent::Output.__send__(:include, MeasureTimable)
+    end
+
+    def emit(tag, time, msg)
     end
   end
 end


### PR DESCRIPTION
It was not working because the plugin loading sequence was changed from v0.10.

v0.10 loads sources first, then loads matches. Therefore, input plugin was load at earlier stage.
v0.12 changed. It loads matches, then sources because of label feature. 

To make measure_time plugin to be required the first among plugins, it must provide output plugin version for v0.12. 
